### PR TITLE
[LTB-4160] Use this beat to fetch information from sidekiq only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 
 .DS_Store
 /sidekiqbeat
+/sidekiqbeat.*
 /sidekiqbeat.test
 *.pyc

--- a/config/config.go
+++ b/config/config.go
@@ -7,6 +7,14 @@ import "time"
 
 type Config struct {
 	Period time.Duration `config:"period"`
+	Connection struct {
+		Sidekiq struct {
+			Password string `config:"password"`
+			Host     string `config:"host"`
+			Port     string `config:"port"`
+			Type     string `config:"type"`
+		} `config:"sidekiq"`
+	} `config:"connection"`
 }
 
 var DefaultConfig = Config{

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-ole/go-ole v1.2.5-0.20190920104607-14974a1cf647 // indirect
+	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -648,6 +648,8 @@ github.com/go-openapi/validate v0.19.12/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0
 github.com/go-openapi/validate v0.19.15/go.mod h1:tbn/fdOwYHgrhPBzidZfJC2MIVvs9GA7monOmWBbeCI=
 github.com/go-openapi/validate v0.20.1/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE9E4k54HpKcJ0=
 github.com/go-openapi/validate v0.20.2/go.mod h1:e7OJoKNgd0twXZwIn0A43tHbvIcr/rZIVCbJBpTUoY0=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=

--- a/queues/sidekiq.go
+++ b/queues/sidekiq.go
@@ -1,0 +1,78 @@
+package queues
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/go-redis/redis"
+	"github.com/resumecompanion/sidekiqbeat/config"
+)
+
+// Sidekiq for connect redis
+type Sidekiq struct {
+	Cfg          *config.Config
+	DbConnection *redis.Client
+}
+
+// Connect is to connect redis
+func (sk *Sidekiq) Connect() {
+	connAddr := fmt.Sprintf("%s:%s", sk.Cfg.Connection.Sidekiq.Host, sk.Cfg.Connection.Sidekiq.Port)
+	sk.DbConnection = redis.NewClient(&redis.Options{
+		Addr:     connAddr,
+		Password: sk.Cfg.Connection.Sidekiq.Password,
+		DB:       0, // use default DB
+	})
+
+	_, err := sk.DbConnection.Ping().Result()
+	if err != nil {
+		logp.Warn("could not connect to redis")
+		return
+	}
+}
+
+func (sk Sidekiq) Close() {
+	sk.DbConnection.Close()
+}
+
+// CollectMetrics is to collecting all required output
+func (sk Sidekiq) CollectMetrics() common.MapStr {
+	r := common.MapStr{
+		"schedule_jobs": sk.scheduleJobs(),
+		"failed_jobs":   sk.failedJobs(),
+	}
+
+	queues := sk.queuesList()
+	for _, queue := range queues {
+		k := fmt.Sprintf("%s_jobs", queue)
+		r[k] = sk.queueData(queue)
+	}
+
+	return r
+}
+
+func (sk Sidekiq) failedJobs() int {
+	tProcess := fmt.Sprintf("stat:failed:%s", time.Now().Format("2006-01-02"))
+	fJ, _ := sk.DbConnection.Get(tProcess).Result()
+	r, _ := strconv.Atoi(fJ)
+	return r
+}
+
+func (sk Sidekiq) scheduleJobs() int {
+	result, _ := sk.DbConnection.ZRange("schedule", 0, -1).Result()
+	return len(result)
+}
+
+func (sk Sidekiq) queueData(q string) int {
+	queueName := fmt.Sprintf("queue:%s", q)
+	queueCount, _ := sk.DbConnection.LRange(queueName, 0, -1).Result()
+
+	return len(queueCount)
+}
+
+func (sk Sidekiq) queuesList() []string {
+	queueList, _ := sk.DbConnection.SMembers("queues").Result()
+	return queueList
+}


### PR DESCRIPTION
Since our background job runner are now only sidekiq, we don't need to
use same beat to parse data from different background processor
based on the config provided in config yml

And regenerate whole beat based on git tag 7.16 provided by official
beats